### PR TITLE
Add legacy-compatible API shims for matcher/context hooks

### DIFF
--- a/freetlelib/src/main/scala/org/freetle/CPSXMLModel.scala
+++ b/freetlelib/src/main/scala/org/freetle/CPSXMLModel.scala
@@ -158,7 +158,18 @@ class CPSXMLModel[@specialized Context] extends CPSModelSerializable[XMLEvent, C
         }
       }
     }
-    def pushToContext(name : QName, attributes : Map[QName, String], namespaces : Map[String, String], context : Context) : Context
+    /**
+     * Namespace-aware context hook (new API).
+     * By default it falls back to the legacy hook for source compatibility.
+     */
+    def pushToContext(name : QName, attributes : Map[QName, String], namespaces : Map[String, String], context : Context) : Context =
+      pushToContext(name, attributes, context)
+
+    /**
+     * Legacy context hook retained for source compatibility.
+     */
+    @deprecated("Use pushToContext(name, attributes, namespaces, context)", "1.3")
+    def pushToContext(name : QName, attributes : Map[QName, String], context : Context) : Context = context
   }
 
   /**
@@ -272,9 +283,17 @@ class CPSXMLModel[@specialized Context] extends CPSModelSerializable[XMLEvent, C
    */
   abstract class EvStartMatcher(nameSpaceMatcher :NameSpaceMatcher) extends EvTagMatcher {
     /**
-     * implement this to check whether the Element is the one we are looking for.
+     * Namespace-aware matcher hook (new API).
+     * By default it falls back to the legacy matcher for source compatibility.
      */
-    def testElem(name : QName, attributes : Map[QName, String], namespaces : Map[String, String]) : Boolean
+    def testElem(name : QName, attributes : Map[QName, String], namespaces : Map[String, String]) : Boolean =
+      testElem(name, attributes)
+
+    /**
+     * Legacy matcher hook retained for source compatibility.
+     */
+    @deprecated("Use testElem(name, attributes, namespaces)", "1.3")
+    def testElem(name : QName, attributes : Map[QName, String]) : Boolean = false
 
     /**
      * Call the testElem method to check the event.
@@ -293,7 +312,7 @@ class CPSXMLModel[@specialized Context] extends CPSModelSerializable[XMLEvent, C
    * A matcher that matches EvElemStarts based on their localPart.
    */
   class LocalPartEvStartMatcher(localPart : String)(implicit nameSpaceMatcher :NameSpaceMatcher) extends EvStartMatcher(nameSpaceMatcher) {
-    def testElem(name: QName, attributes: Map[QName, String], namespaces : Map[String, String]) =
+    override def testElem(name: QName, attributes: Map[QName, String], namespaces : Map[String, String]) =
           localPart.equals(name.localPart) && nameSpaceMatcher(name)
   }
 

--- a/freetlelib/src/test/scala/org/freetle/SortTest.scala
+++ b/freetlelib/src/test/scala/org/freetle/SortTest.scala
@@ -32,7 +32,7 @@ class SortTest extends CPSXMLModel[TstSortContext]  {
     val a = """<orders><order id="2"/><order id="1"/><order id="3"/></orders>"""
     val inStream = XMLResultStreamUtils.loadXMLResultStream(a)
     val t = <("orders") ~ new SortOperator(<("order") ~ </("order"), ((new TakeAttributesToContext(new LocalPartEvStartMatcher("order")) {
-      def pushToContext(name: QName, attributes: Map[QName, String], namspaces: Map[String, String], context: TstSortContext) = context.copy(name = attributes.getOrElse(new QName(localPart = "id"), ""))
+      override def pushToContext(name: QName, attributes: Map[QName, String], namspaces: Map[String, String], context: TstSortContext) = context.copy(name = attributes.getOrElse(new QName(localPart = "id"), ""))
     } ~ new DeepFilter()) -> drop) ~ >(c => c.name)) ~ </("orders")
     val result = t(new CFilterIdentity(),
                   /* Changing this to a FailsCFilter makes the thing go bust... Do something */new CFilterIdentity()


### PR DESCRIPTION
## Summary
- Preserve source compatibility for legacy extensions that override old signatures without namespaces
- Keep namespace-aware APIs as the primary path
- Add deprecation markers on legacy overloads to guide migration

## Details
- `EvStartMatcher` now keeps a deprecated legacy overload:
  - `testElem(name, attributes)`
  - New `testElem(name, attributes, namespaces)` defaults to calling legacy method
- `TakeAttributesToContext` now keeps a deprecated legacy overload:
  - `pushToContext(name, attributes, context)`
  - New `pushToContext(name, attributes, namespaces, context)` defaults to calling legacy method
- Add required `override` in `SortTest` for Scala 2.13 compilation strictness

## Validation
- `mvn -q -f freetlelib/pom.xml test`
- `mvn -q -f bootstrapxsd/pom.xml test`
